### PR TITLE
Add ListenCloseListen test

### DIFF
--- a/npipe_windows.go
+++ b/npipe_windows.go
@@ -374,6 +374,13 @@ func (l *PipeListener) Close() error {
 	l.closed = true
 	if l.handle != 0 {
 		err := disconnectNamedPipe(l.handle)
+		if err != nil {
+			return err
+		}
+		err = syscall.CloseHandle(l.handle)
+		if err != nil {
+			return err
+		}
 		l.handle = 0
 		return err
 	}

--- a/npipe_windows_test.go
+++ b/npipe_windows_test.go
@@ -92,6 +92,22 @@ func TestDoubleListen(t *testing.T) {
 	}
 }
 
+// TestListenCloseListen tests whether Close() actually closes a named pipe properly.
+func TestListenCloseListen(t *testing.T) {
+	address := `\\.\pipe\TestListenCloseListen`
+	ln1, err := Listen(address)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", address, err)
+	}
+	ln1.Close()
+
+	ln2, err := Listen(address)
+	if err != nil {
+		t.Fatalf("second Listen on %q failed.", address)
+	}
+	ln2.Close()
+}
+
 // TestCancelListen tests whether Accept() can be cancelled by closing the listener.
 func TestCancelAccept(t *testing.T) {
 	address := `\\.\pipe\TestCancelListener`


### PR DESCRIPTION
syscall.CloseHandle needs to be called after DiconnectNamedPipe
