### PR TITLE
Protect PipeListener with a mutex.

### DIFF
--- a/npipe_windows.go
+++ b/npipe_windows.go
@@ -288,16 +288,16 @@ func (l *PipeListener) AcceptPipe() (*PipeConn, error) {
 	// have to create a new handle each time
 	handle := l.handle
 	if handle == 0 {
+		l.listenerMutex.Unlock()
 		var err error
 		handle, err = createPipe(string(l.addr), false)
 		if err != nil {
-			l.listenerMutex.Unlock()
 			return nil, err
 		}
 	} else {
 		l.handle = 0
+		l.listenerMutex.Unlock()
 	}
-	l.listenerMutex.Unlock()
 
 	overlapped, err := newOverlapped()
 	if err != nil {

--- a/npipe_windows_test.go
+++ b/npipe_windows_test.go
@@ -582,7 +582,7 @@ func startClient(address string, done chan bool, convos int, t *testing.T) {
 	var conn *PipeConn
 	select {
 	case conn = <-c:
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatal("Client timed out waiting for dial to resolve")
 	}
 	r := bufio.NewReader(conn)


### PR DESCRIPTION
There's a race condition in which PipeListener.Accept and PipeListener.Close are called from separate goroutines. Either method can mutate the state of the PipeListener (l.closed, l.handler). These sections need to be protected with a mutex.
