### PR TITLE
Test race fixes

### DIFF
--- a/npipe_windows.go
+++ b/npipe_windows.go
@@ -288,16 +288,16 @@ func (l *PipeListener) AcceptPipe() (*PipeConn, error) {
 	// have to create a new handle each time
 	handle := l.handle
 	if handle == 0 {
+		l.listenerMutex.Unlock()
 		var err error
 		handle, err = createPipe(string(l.addr), false)
 		if err != nil {
-			l.listenerMutex.Unlock()
 			return nil, err
 		}
 	} else {
 		l.handle = 0
+		l.listenerMutex.Unlock()
 	}
-	l.listenerMutex.Unlock()
 
 	overlapped, err := newOverlapped()
 	if err != nil {

--- a/npipe_windows_test.go
+++ b/npipe_windows_test.go
@@ -582,7 +582,7 @@ func startClient(address string, done chan bool, convos int, t *testing.T) {
 	var conn *PipeConn
 	select {
 	case conn = <-c:
-	case <-time.After(250 * time.Millisecond):
+	case <-time.After(5 * time.Second):
 		t.Fatal("Client timed out waiting for dial to resolve")
 	}
 	r := bufio.NewReader(conn)


### PR DESCRIPTION
Depends on #17. This fixes all the `go test -race ./...` errors in the v2 branch, but TestGoRPC still randomly hangs on `waitForCompletion` -- which tells me there's possibly still an issue with concurrent goroutines in Accept() and Close().

@natefinch @gabriel-samfira Any ideas?
