### PR TITLE
Fix the bug closing same windows handler twice.

### DIFF
--- a/npipe_windows.go
+++ b/npipe_windows.go
@@ -305,7 +305,10 @@ func (l *PipeListener) AcceptPipe() (*PipeConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer syscall.CloseHandle(overlapped.HEvent)
+	defer func() {
+		// make sure we are accessing the newest HEvent value
+		syscall.CloseHandle(overlapped.HEvent)
+	}()
 	err = connectNamedPipe(handle, overlapped)
 	if err == nil || err == error_pipe_connected {
 		return &PipeConn{handle: handle, addr: l.addr}, nil


### PR DESCRIPTION
The overlapped.HEvent has been closed in PipeListener.Close and reset to 0. But close again in PipeListener.AcceptPipe with origin HEvent. So that throw a panic which cannot be recovered.